### PR TITLE
Update search.php

### DIFF
--- a/lib/search.php
+++ b/lib/search.php
@@ -465,6 +465,7 @@ function relevanssi_search($args) {
 
 	$query_restrictions = apply_filters('relevanssi_where', $query_restrictions); // Charles St-Pierre
 	if (!empty($meta_join)) $query_join = $meta_join;
+	if (!isset($query_join)) { $query_join =  ''; } //David Stein
 	$query_join = apply_filters('relevanssi_join', $query_join);
 
 	$no_matches = true;


### PR DESCRIPTION
Latest version on WP 4.2 creates this error on every search:

Notice: Undefined variable: query_join in /home/public_html/dev/content-wp/plugins/relevanssi/lib/search.php on line 468

Very trivial fix. 
I looked in the previous version and saw the $query_join was filter was based on a null string, and so if undefined I then define it to that same value. 

DS
